### PR TITLE
Remove unnecessary files from dist/archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+phpcs.xml export-ignore
+phpunit.xml export-ignore
+tests export-ignore

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,18 @@
   "autoload-dev": {
     "files": ["wp-password-bcrypt.php"]
   },
+  "archive" : {
+    "exclude": [
+      ".editorconfig",
+      ".gitattributes",
+      ".gitignore",
+      ".travis.yml",
+      "CONTRIBUTING.md",
+      "phpcs.xml",
+      "phpunit.xml",
+      "tests"
+    ]
+  },
   "scripts": {
     "test": [
       "vendor/bin/phpcs",


### PR DESCRIPTION
I think I did this right. 

Here's an example of the files that are included with this PR: https://github.com/roots/wp-password-bcrypt/archive/guap-distfiles.zip

This will be for users who use `--prefer-dist` with composer and users who click the download zip button here on gitHub.