### PR TITLE
PHP 7.0 deprecates salt option. Let's disallow it too.

### DIFF
--- a/tests/wp-password-bcrypt-test.php
+++ b/tests/wp-password-bcrypt-test.php
@@ -50,11 +50,11 @@ class WpPasswordBcryptTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function hashing_password_applies_filter()
+    public function hashing_password_applies_cost_filter()
     {
         wp_hash_password(self::PASSWORD);
 
-        Filters::expectApplied('wp_hash_password_options')->andReturn(self::HASH_BCRYPT);
+        Filters::expectApplied('wp_hash_password_cost')->andReturn(self::HASH_BCRYPT);
     }
 
     /** @test */

--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -51,8 +51,8 @@ function wp_check_password($password, $hash, $userId = '')
  */
 function wp_hash_password($password)
 {
-    $options = apply_filters('wp_hash_password_options', []);
-    return password_hash($password, PASSWORD_DEFAULT, $options);
+    $cost = apply_filters('wp_hash_password_cost', 10);
+    return password_hash($password, PASSWORD_DEFAULT, ['cost' => $cost]);
 }
 
 /**


### PR DESCRIPTION
> **Warning** The salt option has been deprecated as of PHP 7.0.0. It is now preferred to simply use the salt that is generated by default.

http://php.net/manual/en/function.password-hash.php
