### PR TITLE
Support WP application passwords

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,9 @@
     <arg value="sp"/>
 
     <!-- PHP compatibility takes precedent over PSR12 -->
-    <rule ref="PHPCompatibility"/>
+    <rule ref="PHPCompatibility">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
     <rule ref="PSR12"/>
 
     <!-- Support for PHP 5.6+ -->

--- a/tests/Constants.php
+++ b/tests/Constants.php
@@ -2,8 +2,6 @@
 
 namespace Roots\PasswordBcrypt\Tests;
 
-// phpcs:disable PHPCompatibility.Classes.NewConstVisibility.Found
-
 class Constants
 {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,8 +5,6 @@ namespace Roots\PasswordBcrypt\Tests;
 use Brain\Monkey;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-// phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
-
 class TestCase extends MockeryTestCase
 {
     use MocksWpdb;

--- a/tests/Unit/ApplicationPasswordTest.php
+++ b/tests/Unit/ApplicationPasswordTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Roots\PasswordBcrypt\Tests\Unit;
+
+use Roots\PasswordBcrypt\Tests\TestCase;
+use Roots\PasswordBcrypt\Tests\Constants;
+use Mockery;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Filters\expectApplied;
+
+class ApplicationPasswordTest extends TestCase
+{
+
+    /** @test */
+    public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
+    {
+        require_once __DIR__ . '/../WPApplicationPasswords.php';
+
+        expectApplied('application_password_is_api_request')
+            ->andReturn(true);
+
+        $this
+            ->wpHasher()
+            ->shouldReceive('CheckPassword')
+            ->times(3)
+            ->andReturnValues([true, true, false]);
+
+        expect('update_user_meta')
+            ->once()
+            ->withArgs(function (...$args) {
+                [$userId, $metaKey, $passwords] = $args;
+
+                if ($userId != Constants::USER_ID) {
+                    return false;
+                }
+
+                if ($metaKey != \WP_Application_Passwords::USERMETA_KEY_APPLICATION_PASSWORDS) {
+                    return false;
+                }
+
+                if (count($passwords) != 3) {
+                    return false;
+                }
+
+                if (!key_exists(0, $passwords)) {
+                    return false;
+                }
+
+                $passwords = array_map((function ($item) {
+                    return $item['password'];
+                }), $passwords);
+
+                [$pw1, $pw2, $pw3] = $passwords;
+
+                if (!password_verify(Constants::PASSWORD, $pw1)) {
+                    return false;
+                }
+
+                if (!password_verify(Constants::PASSWORD, $pw2)) {
+                    return false;
+                }
+
+                if (password_verify(Constants::PASSWORD, $pw3)) {
+                    return false;
+                }
+
+                return true;
+            });
+
+        $hash = wp_set_password(Constants::PASSWORD, Constants::USER_ID);
+    }
+}

--- a/tests/WPApplicationPasswords.php
+++ b/tests/WPApplicationPasswords.php
@@ -1,0 +1,25 @@
+<?php
+
+use Roots\PasswordBcrypt\Tests\Constants;
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class WP_Application_Passwords
+{
+    public const USERMETA_KEY_APPLICATION_PASSWORDS = '_application_passwords';
+
+    public static function get_user_application_passwords($userId)
+    {
+        return [
+            [
+                'password' => Constants::PHPPASS_HASH
+            ],
+            [
+                'password' => Constants::BCRYPT_HASH
+            ],
+            [
+                'password' => Constants::INVALID_HASH
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #22

Handles API requests and updates application passwords to bcrypt when applicable.

Note: extracted from https://github.com/roots/wp-password-bcrypt/pull/26 with some changes (mainly the added test)