### PR TITLE
Add hook before_wp_hash_password

### DIFF
--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -69,6 +69,7 @@ function wp_check_password($password, $hash, $user_id = '')
  */
 function wp_hash_password($password)
 {
+    do_action('before_wp_hash_password', $password);
     return password_hash(
         $password,
         PASSWORD_DEFAULT,


### PR DESCRIPTION
Makes plugin compatible with WP Remote Users Sync (https://wordpress.org/plugins/wp-remote-users-sync/)
See discussion: https://discourse.roots.io/t/make-wp-password-bcrypt-compatible-with-wp-remote-users-sync-just-1-line/22006