### PR TITLE
fix: Deprecation Errors in CI Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
           coverage: xdebug
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-8.0.x-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
# This PR Fixes
* Upgrade `actions/checkout` to v4.
* Upgrade `actions/cache` to v3.
* Replace: deprecated COMPOSER_TOKEN variable in favor of GITHUB_TOKEN.
* fix: The set-output command is deprecated and will be disabled soon.

<img width="1118" alt="Screenshot 2024-02-02 at 7 13 03 PM" src="https://github.com/roots/wp-password-bcrypt/assets/6929121/d3cfa7cf-b533-48ef-9907-1460f2b1d7f3">

<img width="857" alt="Screenshot 2024-02-02 at 7 09 32 PM" src="https://github.com/roots/wp-password-bcrypt/assets/6929121/58b05b94-0f98-479e-bfb8-6cde33473147">
