### PR TITLE
Add the `wp_set_password` action to match WordPress core since 6.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The `check_password` filter is available just like the default WP function.
 
 This function is included here verbatim but with the addition of returning the hash. The default WP function does not return anything which means you end up hashing it twice for no reason.
 
+The `wp_set_password` action is available just like the default WP function.
+
 ## FAQ
 
 **What happens to existing passwords when I install the plugin?**

--- a/tests/Unit/UserPasswordTest.php
+++ b/tests/Unit/UserPasswordTest.php
@@ -7,6 +7,7 @@ use Roots\PasswordBcrypt\Tests\Constants;
 
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Actions\expectDone;
 
 class UserPasswordTest extends TestCase
 {
@@ -35,6 +36,20 @@ class UserPasswordTest extends TestCase
 
         expectApplied('wp_hash_password_options')
             ->andReturn(Constants::BCRYPT_HASH);
+    }
+
+    /** @test */
+    public function setting_password_does_action()
+    {
+        expect('clean_user_cache')
+            ->once()
+            ->andReturn(true);
+
+        expectDone('wp_set_password')
+            ->once()
+            ->with(Constants::PASSWORD, Constants::USER_ID);
+
+        wp_set_password(Constants::PASSWORD, Constants::USER_ID);
     }
 
     /** @test */

--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -102,6 +102,14 @@ function wp_set_password($password, $user_id)
 
         clean_user_cache($user_id);
 
+        /**
+         * Fires after the user password is set.
+         *
+         * @param string  $password The plaintext password just set.
+         * @param int     $user_id  The ID of the user whose password was just set.
+         */
+        do_action('wp_set_password', $password, $user_id);
+
         return $hash;
     }
 


### PR DESCRIPTION
In WordPress 6.2 a new `wp_set_password` action was added to the `wp_set_password()` function. Ref: https://github.com/WordPress/wordpress-develop/commit/344c4dce6881a5649ba69b50a6e9b89ff4a890ef

This adds that action.

In WordPres 6.7 an additional `$old_user_data` parameter has been added, but we can add that once 6.7 is released.