### PR TITLE
Ensure the hashed password is always returned

### DIFF
--- a/tests/EmptyWPApplicationPasswords.php
+++ b/tests/EmptyWPApplicationPasswords.php
@@ -1,0 +1,13 @@
+<?php
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class WP_Application_Passwords
+{
+    public const USERMETA_KEY_APPLICATION_PASSWORDS = '_application_passwords';
+
+    public static function get_user_application_passwords($userId)
+    {
+        return [];
+    }
+}

--- a/tests/Unit/ApplicationPasswordTest.php
+++ b/tests/Unit/ApplicationPasswordTest.php
@@ -12,7 +12,10 @@ use function Brain\Monkey\Filters\expectApplied;
 class ApplicationPasswordTest extends TestCase
 {
 
-    /** @test */
+    /**
+     * @test
+     * @runInSeparateProcess
+     */
     public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
     {
         require_once __DIR__ . '/../WPApplicationPasswords.php';
@@ -69,5 +72,7 @@ class ApplicationPasswordTest extends TestCase
             });
 
         $hash = wp_set_password(Constants::PASSWORD, Constants::USER_ID);
+
+        $this->assertIsString($hash);
     }
 }

--- a/tests/Unit/EmptyApplicationPasswordTest.php
+++ b/tests/Unit/EmptyApplicationPasswordTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Roots\PasswordBcrypt\Tests\Unit;
+
+use Roots\PasswordBcrypt\Tests\TestCase;
+use Roots\PasswordBcrypt\Tests\Constants;
+
+use function Brain\Monkey\Filters\expectApplied;
+
+class EmptyApplicationPasswordTest extends TestCase
+{
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     */
+    public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
+    {
+        require_once __DIR__ . '/../EmptyWPApplicationPasswords.php';
+
+        expectApplied('application_password_is_api_request')
+            ->andReturn(true);
+
+        $this
+            ->wpHasher()
+            ->shouldReceive('CheckPassword')
+            ->times(3)
+            ->andReturnValues([true, true, false]);
+
+        $hash = wp_set_password(Constants::PASSWORD, Constants::USER_ID);
+
+        $this->assertIsString($hash);
+    }
+}

--- a/tests/Unit/RESTAPITest.php
+++ b/tests/Unit/RESTAPITest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Roots\PasswordBcrypt\Tests\Unit;
+
+use Roots\PasswordBcrypt\Tests\TestCase;
+use Roots\PasswordBcrypt\Tests\Constants;
+
+use function Brain\Monkey\Filters\expectApplied;
+
+class RESTAPIPasswordTest extends TestCase
+{
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     */
+    public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
+    {
+        expectApplied('application_password_is_api_request')
+            ->andReturn(true);
+
+        $this
+            ->wpHasher()
+            ->shouldReceive('CheckPassword')
+            ->times(3)
+            ->andReturnValues([true, true, false]);
+
+        $hash = wp_set_password(Constants::PASSWORD, Constants::USER_ID);
+
+        $this->assertFalse(class_exists('WP_Application_Passwords'));
+        $this->assertIsString($hash);
+    }
+}

--- a/tests/Unit/UserPasswordTest.php
+++ b/tests/Unit/UserPasswordTest.php
@@ -23,8 +23,11 @@ class UserPasswordTest extends TestCase
             ->once()
             ->andReturn(true);
 
+        $hash = wp_set_password(Constants::PASSWORD, Constants::USER_ID);
+
+        $this->assertIsString($hash);
         $this->assertTrue(
-            password_verify(Constants::PASSWORD, wp_set_password(Constants::PASSWORD, Constants::USER_ID))
+            password_verify(Constants::PASSWORD, $hash)
         );
     }
 

--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -81,7 +81,7 @@ function wp_hash_password($password)
  *
  * @param  string $password The new user password in plaintext.
  * @param  int    $user_id  The user ID.
- * @return string
+ * @return string The new hashed password.
  */
 function wp_set_password($password, $user_id)
 {
@@ -109,7 +109,7 @@ function wp_set_password($password, $user_id)
         ! class_exists('WP_Application_Passwords') ||
         empty($passwords = WP_Application_Passwords::get_user_application_passwords($user_id))
     ) {
-        return;
+        return $hash;
     }
 
     global $wp_hasher;


### PR DESCRIPTION
There's a rogue `return;` in the `wp_set_password()` function. This fixes that.

The application password tests for this need to be run in separate processes to avoid trying to redeclare `WP_Application_Passwords` during testing.