### PR TITLE
Add the `$old_user_data` parameter to the `wp_set_password` action to match WordPress 6.7

### DIFF
--- a/tests/Unit/ApplicationPasswordTest.php
+++ b/tests/Unit/ApplicationPasswordTest.php
@@ -29,6 +29,10 @@ class ApplicationPasswordTest extends TestCase
             ->times(3)
             ->andReturnValues([true, true, false]);
 
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
+
         expect('update_user_meta')
             ->once()
             ->withArgs(function (...$args) {

--- a/tests/Unit/ApplicationPasswordTest.php
+++ b/tests/Unit/ApplicationPasswordTest.php
@@ -31,6 +31,7 @@ class ApplicationPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expect('update_user_meta')

--- a/tests/Unit/EmptyApplicationPasswordTest.php
+++ b/tests/Unit/EmptyApplicationPasswordTest.php
@@ -5,6 +5,7 @@ namespace Roots\PasswordBcrypt\Tests\Unit;
 use Roots\PasswordBcrypt\Tests\TestCase;
 use Roots\PasswordBcrypt\Tests\Constants;
 
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Filters\expectApplied;
 
 class EmptyApplicationPasswordTest extends TestCase
@@ -17,6 +18,10 @@ class EmptyApplicationPasswordTest extends TestCase
     public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
     {
         require_once __DIR__ . '/../EmptyWPApplicationPasswords.php';
+
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
 
         expectApplied('application_password_is_api_request')
             ->andReturn(true);

--- a/tests/Unit/EmptyApplicationPasswordTest.php
+++ b/tests/Unit/EmptyApplicationPasswordTest.php
@@ -21,6 +21,7 @@ class EmptyApplicationPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expectApplied('application_password_is_api_request')

--- a/tests/Unit/RESTAPITest.php
+++ b/tests/Unit/RESTAPITest.php
@@ -5,6 +5,7 @@ namespace Roots\PasswordBcrypt\Tests\Unit;
 use Roots\PasswordBcrypt\Tests\TestCase;
 use Roots\PasswordBcrypt\Tests\Constants;
 
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Filters\expectApplied;
 
 class RESTAPIPasswordTest extends TestCase
@@ -16,6 +17,10 @@ class RESTAPIPasswordTest extends TestCase
      */
     public function phpass_application_passwords_should_be_verified_and_converted_to_bcrypt()
     {
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
+
         expectApplied('application_password_is_api_request')
             ->andReturn(true);
 

--- a/tests/Unit/RESTAPITest.php
+++ b/tests/Unit/RESTAPITest.php
@@ -19,6 +19,7 @@ class RESTAPIPasswordTest extends TestCase
     {
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expectApplied('application_password_is_api_request')

--- a/tests/Unit/UserPasswordTest.php
+++ b/tests/Unit/UserPasswordTest.php
@@ -22,6 +22,7 @@ class UserPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expect('clean_user_cache')
@@ -54,6 +55,7 @@ class UserPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn($data);
 
         expect('clean_user_cache')
@@ -104,6 +106,7 @@ class UserPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expect('clean_user_cache')
@@ -135,6 +138,7 @@ class UserPasswordTest extends TestCase
 
         expect('get_userdata')
             ->once()
+            ->with(Constants::USER_ID)
             ->andReturn([]);
 
         expect('clean_user_cache')

--- a/tests/Unit/UserPasswordTest.php
+++ b/tests/Unit/UserPasswordTest.php
@@ -20,6 +20,10 @@ class UserPasswordTest extends TestCase
             ->withAnyArgs()
             ->andReturnNull();
 
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
+
         expect('clean_user_cache')
             ->once()
             ->andReturn(true);
@@ -44,13 +48,21 @@ class UserPasswordTest extends TestCase
     /** @test */
     public function setting_password_does_action()
     {
+        $data = [
+            'ID' => Constants::USER_ID,
+        ];
+
+        expect('get_userdata')
+            ->once()
+            ->andReturn($data);
+
         expect('clean_user_cache')
             ->once()
             ->andReturn(true);
 
         expectDone('wp_set_password')
             ->once()
-            ->with(Constants::PASSWORD, Constants::USER_ID);
+            ->with(Constants::PASSWORD, Constants::USER_ID, $data);
 
         wp_set_password(Constants::PASSWORD, Constants::USER_ID);
     }
@@ -90,6 +102,10 @@ class UserPasswordTest extends TestCase
             ->with(Constants::PASSWORD, Constants::PHPPASS_HASH)
             ->andReturn(true);
 
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
+
         expect('clean_user_cache')
             ->once()
             ->andReturn(true);
@@ -116,6 +132,10 @@ class UserPasswordTest extends TestCase
             ->once()
             ->with(Constants::PASSWORD, Constants::PHPPASS_HASH)
             ->andReturn(true);
+
+        expect('get_userdata')
+            ->once()
+            ->andReturn([]);
 
         expect('clean_user_cache')
             ->once()

--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -108,7 +108,7 @@ function wp_set_password($password, $user_id)
          *
          * @param string  $password      The plaintext password just set.
          * @param int     $user_id       The ID of the user whose password was just set.
-		 * @param WP_User $old_user_data Object containing user's data prior to update.
+         * @param WP_User $old_user_data Object containing user's data prior to update.
          */
         do_action('wp_set_password', $password, $user_id, $old_user_data);
 

--- a/wp-password-bcrypt.php
+++ b/wp-password-bcrypt.php
@@ -85,6 +85,7 @@ function wp_hash_password($password)
  */
 function wp_set_password($password, $user_id)
 {
+    $old_user_data = get_userdata($user_id);
     $hash = wp_hash_password($password);
     $is_api_request = apply_filters(
         'application_password_is_api_request',
@@ -105,10 +106,11 @@ function wp_set_password($password, $user_id)
         /**
          * Fires after the user password is set.
          *
-         * @param string  $password The plaintext password just set.
-         * @param int     $user_id  The ID of the user whose password was just set.
+         * @param string  $password      The plaintext password just set.
+         * @param int     $user_id       The ID of the user whose password was just set.
+		 * @param WP_User $old_user_data Object containing user's data prior to update.
          */
-        do_action('wp_set_password', $password, $user_id);
+        do_action('wp_set_password', $password, $user_id, $old_user_data);
 
         return $hash;
     }


### PR DESCRIPTION
Following on from #40, the `wp_set_password` action will get an additional `$old_user_data` parameter in WordPress 6.7.

Refs:

- https://core.trac.wordpress.org/changeset/58653
- https://core.trac.wordpress.org/ticket/61541